### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,7 +1,7 @@
 Neotimer	KEYWORD1
 start	KEYWORD2
 stop	KEYWORD2
-restart KEYWORD2
+restart	KEYWORD2
 reset	KEYWORD2
 done	KEYWORD2
 waiting	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords