### PR TITLE
Type choice enhancements

### DIFF
--- a/src/neotimer.h
+++ b/src/neotimer.h
@@ -1,23 +1,20 @@
 #ifndef NEOTIMER_H
 #define NEOTIMER_H
 
-#define NEOTIMER_INDEFINITE -1
-#define NEOTIMER_UNLIMITED -1
-
+constexpr unsigned long NEOTIMER_INDEFINITE = -1;
+constexpr unsigned long NEOTIMER_UNLIMITED  = -1;
 
 #include <Arduino.h>
 
 class Neotimer{
 	public:
-	//Methods
 	Neotimer();
-	Neotimer(long _t);      //Constructor
-	~Neotimer();            //Destructor
+	Neotimer(unsigned long t);      //Constructor
 		
 	void init();            //Initializations
 	boolean done();         //Indicates time has elapsed
-	boolean repeat(int times);
-	boolean repeat(int times, long _t);
+	boolean repeat(unsigned long times);
+	boolean repeat(unsigned long times, unsigned long t);
 	boolean repeat();
 	void repeatReset();
 	boolean waiting();			// Indicates timer is started but not finished
@@ -26,16 +23,15 @@ class Neotimer{
 	long stop();			//Stops a timer and returns elapsed time
 	void restart();
 	void reset();           //Resets timer to zero
-	void set(long t);
-	long get();
+	void set(unsigned long t);
+	unsigned long get();
 	boolean debounce(boolean signal);
-	int repetitions = NEOTIMER_UNLIMITED;
+	unsigned long repetitions = NEOTIMER_UNLIMITED;
 	
 	private:
-
-	typedef struct myTimer{
-		long time;
-		long last;
+	struct myTimer{
+		unsigned long time;
+		unsigned long last;
 		boolean done;
 		boolean started;
 	};
@@ -45,17 +41,10 @@ class Neotimer{
 };
 
 //Default constructor
-Neotimer::Neotimer(){
-	this->_timer.time = 1000; //Default 1 second interval if not specified
-}
+Neotimer::Neotimer(): Neotimer(1000) {}
 
-Neotimer::Neotimer(long _t){
-  this->_timer.time = _t;
-}
-
-//Default destructor
-Neotimer::~Neotimer(){
-  
+Neotimer::Neotimer(unsigned long t){
+  this->_timer.time = t;
 }
 
 //Initializations
@@ -71,24 +60,23 @@ void Neotimer::init(){
  * 	  do something 10 times, every second (default)
  * }
  */
-boolean Neotimer::repeat(int times){
-	if(times != NEOTIMER_UNLIMITED){	
-		// First repeat
-		if(this->repetitions == NEOTIMER_UNLIMITED){
-			this->repetitions = times;			
-		}
-		// Stop
-		if(this->repetitions == 0){
-			return false;
-		}
-		
-		if(this->repeat()){
-			this->repetitions--;
-			return true;
-		}
-		return false;
-	}
-	return this->repeat();
+boolean Neotimer::repeat(unsigned long times){
+  if(times != NEOTIMER_UNLIMITED){	
+    // First repeat
+    if(this->repetitions == NEOTIMER_UNLIMITED){
+      this->repetitions = times;			
+    }
+    // Stop
+    if(this->repetitions == 0){
+      return false;
+    }
+    if(this->repeat()){
+      this->repetitions--;
+      return true;
+    }
+    return false;
+  }
+  return this->repeat();
 }
 
 /*
@@ -99,9 +87,9 @@ boolean Neotimer::repeat(int times){
  * 	  do something 10 times, every 5 seconds
  * }
  */
-boolean Neotimer::repeat(int times, long _t){
-	this->_timer.time = _t;
-	return this->repeat(times);
+boolean Neotimer::repeat(unsigned long times, unsigned long t){
+  this->_timer.time = t;
+  return this->repeat(times);
 }
 
 /*
@@ -117,16 +105,16 @@ boolean Neotimer::repeat(){
     this->reset();
     return true;
   }  
-	if(!this->_timer.started){
-		this->_timer.last = millis();
-		this->_timer.started = true;
+  if(!this->_timer.started){
+    this->_timer.last = millis();
+    this->_timer.started = true;
     this->_waiting = true;
   }	
   return false;	
 }
 
 void Neotimer::repeatReset(){
-	this->repetitions = -1;
+  this->repetitions = -1;
 }
 
 /*
@@ -135,7 +123,7 @@ void Neotimer::repeatReset(){
  */
 boolean Neotimer::done(){
   if(!this->_timer.started) return false;
-  if( (millis()-this->_timer.last) >= this->_timer.time){
+  if( ( millis()-this->_timer.last ) >= this->_timer.time ){
     this->_timer.done = true;
     this->_waiting = false;
     return true;
@@ -146,15 +134,15 @@ boolean Neotimer::done(){
 /*
  * Sets a timer preset
  */
-void Neotimer::set(long t){
+void Neotimer::set(unsigned long t){
   this->_timer.time = t;
 }
 
 /*
  * Gets the timer preset
  */
-long Neotimer::get(){
-	return this->_timer.time;
+unsigned long Neotimer::get(){
+  return this->_timer.time;
 }
 
 /*
@@ -163,11 +151,11 @@ long Neotimer::get(){
  * of electromechanical signals
  */
 boolean Neotimer::debounce(boolean signal){
-	if(this->done() && signal){
-		this->start();
-		return true;
-	}
-	return false;
+  if(this->done() && signal){
+    this->start();
+    return true;
+  }
+  return false;
 }
 
 /*
@@ -183,7 +171,7 @@ void Neotimer::reset(){
  * Start a timer
  */
 void Neotimer::start(){
-	this->reset();
+  this->reset();
   this->_timer.started = true;
   this->_waiting = true;
 }
@@ -201,10 +189,10 @@ long Neotimer::stop(){
  * Continues a stopped timer
  */
 void Neotimer::restart(){
-	if(!this->done()){
-		this->_timer.started = true;
-		this->_waiting = true;
-	}
+  if(!this->done()){
+    this->_timer.started = true;
+    this->_waiting = true;
+  }
 }
 
 /*
@@ -216,7 +204,7 @@ boolean Neotimer::waiting(){
 }
 
 boolean Neotimer::started(){
-	return this->_timer.started;
+  return this->_timer.started;
 }
 
 #endif


### PR DESCRIPTION
All signed ints has been converted to unsigned long.
This is logically appropriate as timers and counters should never go negative.
In addition it also suppresses some compiler warning (-Wsign-compare).

I suspect that the original choice was motivated by the special values NEOTIMER_INDEFINITE and NEOTIMER_UNLIMITED. These have been adjusted to the maximum allowable value for the unsigned long type by replacing the #define statement with constexpr.